### PR TITLE
Fixes

### DIFF
--- a/Sniffs/Classes/InstantiateNewClassesSniff.php
+++ b/Sniffs/Classes/InstantiateNewClassesSniff.php
@@ -1,107 +1,99 @@
 <?php
 /**
- * Ensures that new classes are instantiated without brackets if they do not
- * have any parameters.
+ * Joomla! Coding Standard
  *
- * @category  Classes
- * @package   Joomla.CodeSniffer
- * @author    Nikolai Plath
- * @version   CVS: $Id: InstantiateNewClassesSniff.php 508 2011-08-29 08:53:08Z elkuku $
+ * @copyright  Copyright (C) Open Source Matters, Inc. All rights reserved.
+ * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 
 /**
- * Ensures that new classes are instantiated without brackets if they do not
- * have any parameters.
- *
- * @category  Classes
- * @package   Joomla.CodeSniffer
+ * Ensures that new classes are instantiated without brackets if they do not have any parameters.
  */
 class Joomla_Sniffs_Classes_InstantiateNewClassesSniff implements PHP_CodeSniffer_Sniff
 {
-    /**
-     * Registers the token types that this sniff wishes to listen to.
-     *
-     * @return array
-     */
-    public function register()
-    {
-        return array(T_NEW);
-    }//end register()
+	/**
+	 * Registers the token types that this sniff wishes to listen to.
+	 *
+	 * @return  array
+	 */
+	public function register()
+	{
+		return array(T_NEW);
+	}
 
-    /**
-     * Process the tokens that this sniff is listening for.
-     *
-     * @param PHP_CodeSniffer_File $phpcsFile The file where the token was found.
-     * @param int                  $stackPtr  The position in the stack where
-     *                                        the token was found.
-     *
-     * @return void
-     */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
-    {
-        $tokens = $phpcsFile->getTokens();
+	/**
+	 * Process the tokens that this sniff is listening for.
+	 *
+	 * @param   PHP_CodeSniffer_File  $phpcsFile  The file where the token was found.
+	 * @param   integer               $stackPtr   The position in the stack where the token was found.
+	 *
+	 * @return  void
+	 */
+	public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+	{
+		$tokens = $phpcsFile->getTokens();
 
-        $running = true;
-        $valid = false;
-        $started = false;
+		$running = true;
+		$valid   = false;
+		$started = false;
 
-        $cnt = $stackPtr + 1;
+		$cnt = $stackPtr + 1;
 
-        do
-        {
-            if( ! isset($tokens[$cnt]))
-            {
-                $running = false;
-            }
-            else
-            {
-                switch ($tokens[$cnt]['code'])
-                {
-                    case T_SEMICOLON:
-                    case T_COMMA :
-                        $valid = true;
-                        $running = false;
-                        break;
+		do
+		{
+			if (!isset($tokens[$cnt]))
+			{
+				$running = false;
+			}
+			else
+			{
+				switch ($tokens[$cnt]['code'])
+				{
+					case T_SEMICOLON:
+					case T_COMMA :
+						$valid   = true;
+						$running = false;
+						break;
 
-                    case T_OPEN_PARENTHESIS :
-                        $started = true;
-                        break;
+					case T_OPEN_PARENTHESIS :
+						$started = true;
+						break;
 
-                    case T_VARIABLE :
-                    case T_STRING :
-                    case T_LNUMBER :
-                    case T_CONSTANT_ENCAPSED_STRING :
-                    case T_DOUBLE_QUOTED_STRING :
-                        if($started)
-                        {
-                            $valid = true;
-                            $running = false;
-                        }
+					case T_VARIABLE :
+					case T_STRING :
+					case T_LNUMBER :
+					case T_CONSTANT_ENCAPSED_STRING :
+					case T_DOUBLE_QUOTED_STRING :
+						if ($started)
+						{
+							$valid   = true;
+							$running = false;
+						}
 
-                        break;
+						break;
 
-                    case T_CLOSE_PARENTHESIS :
-                        if( ! $started)
-                        {
-                            $valid = true;
-                        }
+					case T_CLOSE_PARENTHESIS :
+						if (!$started)
+						{
+							$valid = true;
+						}
 
-                         $running = false;
-                        break;
+						$running = false;
+						break;
 
-                    case T_WHITESPACE :
-                        break;
-                }//switch
+					case T_WHITESPACE :
+						break;
+				}
 
-                $cnt ++;
-            }
-        }
-        while ($running == true);
+				$cnt++;
+			}
+		}
+		while ($running == true);
 
-        if( ! $valid)
-        {
-            $error = 'Instanciating new classes without parameters does not require brackets.';
-            $phpcsFile->addError($error, $stackPtr, 'New class');
-        }
-    }//function
-}//class
+		if (!$valid)
+		{
+			$error = 'Instanciating new classes without parameters does not require brackets.';
+			$phpcsFile->addError($error, $stackPtr, 'New class');
+		}
+	}
+}

--- a/Sniffs/Commenting/ClassCommentSniff.php
+++ b/Sniffs/Commenting/ClassCommentSniff.php
@@ -1,186 +1,95 @@
 <?php
 /**
- * Parses and verifies the doc comments for classes.
+ * Joomla! Coding Standard
  *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @copyright  Copyright (C) Open Source Matters, Inc. All rights reserved.
+ * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
+
+if (class_exists('PEAR_Sniffs_Commenting_ClassCommentSniff', true) === false)
+{
+	throw new PHP_CodeSniffer_Exception('Class PEAR_Sniffs_Commenting_ClassCommentSniff not found');
+}
+
 /**
  * Parses and verifies the doc comments for classes.
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
- * @version   Release: @package_version@
- * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
-class Joomla_Sniffs_Commenting_ClassCommentSniff extends PEAR_Sniffs_Commenting_FileCommentSniff
+class Joomla_Sniffs_Commenting_ClassCommentSniff extends PEAR_Sniffs_Commenting_ClassCommentSniff
 {
-     /**
-     * Returns an array of tokens this test wants to listen for.
-     *
-     * @return array
-     */
-    public function register()
-    {
-        return array(
-                    T_CLASS,
-                    T_INTERFACE,
-                     );
+	/**
+	 * Tags in correct order and related info.
+	 *
+	 * @var  array
+	 */
+	protected $tags = array(
+		'@version'    => array(
+			'required'       => false,
+			'allow_multiple' => false,
+			'order_text'     => 'is first',
+		),
+		'@category'   => array(
+			'required'       => false,
+			'allow_multiple' => false,
+			'order_text'     => 'must follow @version (if used)',
+		),
+		'@package'    => array(
+			'required'       => false,
+			'allow_multiple' => false,
+			'order_text'     => 'must follow @category (if used)',
+		),
+		'@subpackage' => array(
+			'required'       => false,
+			'allow_multiple' => false,
+			'order_text'     => 'must follow @package',
+		),
+		'@author'     => array(
+			'required'       => false,
+			'allow_multiple' => true,
+			'order_text'     => 'is first',
+		),
+		'@copyright'  => array(
+			'required'       => false,
+			'allow_multiple' => true,
+			'order_text'     => 'must follow @author (if used) or @subpackage (if used) or @package',
+		),
+		'@license'    => array(
+			'required'       => false,
+			'allow_multiple' => false,
+			'order_text'     => 'must follow @copyright (if used)',
+		),
+		'@link'       => array(
+			'required'       => false,
+			'allow_multiple' => true,
+			'order_text'     => 'must follow @version (if used)',
+		),
+		'@see'        => array(
+			'required'       => false,
+			'allow_multiple' => true,
+			'order_text'     => 'must follow @link (if used)',
+		),
+		'@since'      => array(
+			'required'       => true,
+			'allow_multiple' => false,
+			'order_text'     => 'must follow @see (if used) or @link (if used)',
+		),
+		'@deprecated' => array(
+			'required'       => false,
+			'allow_multiple' => false,
+			'order_text'     => 'must follow @since (if used) or @see (if used) or @link (if used)',
+		),
+	);
 
-    }//end register()
-
-    /**
-     * Tags in correct order and related info.
-     *
-     * @var array
-     */
-    protected $tags = array(
-                       '@version'    => array(
-                                        'required'       => false,
-                                        'allow_multiple' => false,
-                                        'order_text'     => 'is first',
-                                       ),
-                       '@category'    => array(
-                                        'required'       => false,
-                                        'allow_multiple' => false,
-                                        'order_text'     => 'must follow @version (if used)',
-                                       ),
-                       '@package'    => array(
-                                        'required'       => false,
-                                        'allow_multiple' => false,
-                                        'order_text'     => 'must follow @category (if used)',
-                                       ),
-                       '@subpackage' => array(
-                                        'required'       => false,
-                                        'allow_multiple' => false,
-                                        'order_text'     => 'must follow @package',
-                                       ),
-                       '@author'    => array(
-                                        'required'       => false,
-                                        'allow_multiple' => true,
-                                        'order_text'     => 'is first',
-                                       ),
-                       '@copyright'  => array(
-                                        'required'       => false,
-                                        'allow_multiple' => true,
-                                        'order_text'     => 'must follow @author (if used) or @subpackage (if used) or @package',
-                                       ),
-                       '@license'    => array(
-                                        'required'       => false,
-                                        'allow_multiple' => false,
-                                        'order_text'     => 'must follow @copyright (if used)',
-                                       ),
-                       '@link'       => array(
-                                        'required'       => false,
-                                        'allow_multiple' => true,
-                                        'order_text'     => 'must follow @version (if used)',
-                                       ),
-                       '@see'        => array(
-                                        'required'       => false,
-                                        'allow_multiple' => true,
-                                        'order_text'     => 'must follow @link (if used)',
-                                       ),
-                       '@since'      => array(
-                                        'required'       => true,
-                                        'allow_multiple' => false,
-                                        'order_text'     => 'must follow @see (if used) or @link (if used)',
-                                       ),
-                       '@deprecated' => array(
-                                        'required'       => false,
-                                        'allow_multiple' => false,
-                                        'order_text'     => 'must follow @since (if used) or @see (if used) or @link (if used)',
-                                       ),
-                );
-
-    /**
-     * Processes this test, when one of its tokens is encountered.
-     *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
-     *
-     * @return void
-     */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
-    {
-        $this->currentFile = $phpcsFile;
-        $tokens    = $phpcsFile->getTokens();
-        $type      = strtolower($tokens[$stackPtr]['content']);
-        $errorData = array($type);
-
-        $find   = PHP_CodeSniffer_Tokens::$methodPrefixes;
-        $find[] = T_ABSTRACT;
-        $find[] = T_WHITESPACE;
-        $find[] = T_FINAL;
-
-$commentEnd = $phpcsFile->findPrevious($find, ($stackPtr - 1), null, true);
-        if ($tokens[$commentEnd]['code'] !== T_DOC_COMMENT_CLOSE_TAG
-            && $tokens[$commentEnd]['code'] !== T_COMMENT
-        ) {
-            $phpcsFile->addError('Missing class doc comment', $stackPtr, 'Missing');
-            $phpcsFile->recordMetric($stackPtr, 'Class has doc comment', 'no');
-            return;
-        } else {
-            $phpcsFile->recordMetric($stackPtr, 'Class has doc comment', 'yes');
-        }
-        // Try and determine if this is a file comment instead of a class comment.
-        // We assume that if this is the first comment after the open PHP tag, then
-        // it is most likely a file comment instead of a class comment.
-        if ($tokens[$commentEnd]['code'] === T_DOC_COMMENT_CLOSE_TAG) {
-            $start = ($tokens[$commentEnd]['comment_opener'] - 1);
-        } else {
-            $start = $phpcsFile->findPrevious(T_COMMENT, ($commentEnd - 1), null, true);
-        }
-        $prev = $phpcsFile->findPrevious(T_WHITESPACE, $start, null, true);
-        if ($tokens[$prev]['code'] === T_OPEN_TAG) {
-            $prevOpen = $phpcsFile->findPrevious(T_OPEN_TAG, ($prev - 1));
-            if ($prevOpen === false) {
-                // This is a comment directly after the first open tag,
-                // so probably a file comment.
-                $phpcsFile->addError('Missing class doc comment', $stackPtr, 'Missing');
-                return;
-            }
-        }
-        if ($tokens[$commentEnd]['code'] === T_COMMENT) {
-            $phpcsFile->addError('You must use "/**" style comments for a class comment', $stackPtr, 'WrongStyle');
-            return;
-        }
-        // Check each tag.
-        $this->processTags($phpcsFile, $stackPtr, $tokens[$commentEnd]['comment_opener']);
-    }//end process()
-    /**
-     * Process the version tag.
-     *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param array                $tags      The tokens for these tags.
-     *
-     * @return void
-     */
-    protected function processVersion(PHP_CodeSniffer_File $phpcsFile, array $tags)
-    {
-        $tokens = $phpcsFile->getTokens();
-        foreach ($tags as $tag) {
-            if ($tokens[($tag + 2)]['code'] !== T_DOC_COMMENT_STRING) {
-                // No content.
-                continue;
-            }
-            $content = $tokens[($tag + 2)]['content'];
-            if ((strstr($content, 'Release:') === false)) {
-                $error = 'Invalid version "%s" in doc comment; consider "Release: <package_version>" instead';
-                $data  = array($content);
-                $phpcsFile->addWarning($error, $tag, 'InvalidVersion', $data);
-            }
-        }
-    }//end processVersion()
-}//end class
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return  array
+	 */
+	public function register()
+	{
+		return array(
+			T_CLASS,
+			T_INTERFACE,
+			T_TRAIT
+		);
+	}
+}

--- a/Sniffs/Commenting/ClassCommentSniff.php
+++ b/Sniffs/Commenting/ClassCommentSniff.php
@@ -39,64 +39,64 @@ class Joomla_Sniffs_Commenting_ClassCommentSniff extends PEAR_Sniffs_Commenting_
                      );
 
     }//end register()
-    
+
     /**
      * Tags in correct order and related info.
      *
      * @var array
      */
     protected $tags = array(
-                       'version'    => array(
+                       '@version'    => array(
                                         'required'       => false,
                                         'allow_multiple' => false,
                                         'order_text'     => 'is first',
                                        ),
-                       'category'    => array(
+                       '@category'    => array(
                                         'required'       => false,
                                         'allow_multiple' => false,
                                         'order_text'     => 'must follow @version (if used)',
                                        ),
-                       'package'    => array(
+                       '@package'    => array(
                                         'required'       => false,
                                         'allow_multiple' => false,
                                         'order_text'     => 'must follow @category (if used)',
                                        ),
-                       'subpackage' => array(
+                       '@subpackage' => array(
                                         'required'       => false,
                                         'allow_multiple' => false,
                                         'order_text'     => 'must follow @package',
                                        ),
-                       'author'    => array(
+                       '@author'    => array(
                                         'required'       => false,
                                         'allow_multiple' => true,
                                         'order_text'     => 'is first',
                                        ),
-                       'copyright'  => array(
+                       '@copyright'  => array(
                                         'required'       => false,
                                         'allow_multiple' => true,
                                         'order_text'     => 'must follow @author (if used) or @subpackage (if used) or @package',
                                        ),
-                       'license'    => array(
+                       '@license'    => array(
                                         'required'       => false,
                                         'allow_multiple' => false,
                                         'order_text'     => 'must follow @copyright (if used)',
                                        ),
-                       'link'       => array(
+                       '@link'       => array(
                                         'required'       => false,
                                         'allow_multiple' => true,
                                         'order_text'     => 'must follow @version (if used)',
                                        ),
-                       'see'        => array(
+                       '@see'        => array(
                                         'required'       => false,
                                         'allow_multiple' => true,
                                         'order_text'     => 'must follow @link (if used)',
                                        ),
-                       'since'      => array(
+                       '@since'      => array(
                                         'required'       => true,
                                         'allow_multiple' => false,
                                         'order_text'     => 'must follow @see (if used) or @link (if used)',
                                        ),
-                       'deprecated' => array(
+                       '@deprecated' => array(
                                         'required'       => false,
                                         'allow_multiple' => false,
                                         'order_text'     => 'must follow @since (if used) or @see (if used) or @link (if used)',
@@ -118,7 +118,7 @@ class Joomla_Sniffs_Commenting_ClassCommentSniff extends PEAR_Sniffs_Commenting_
         $tokens    = $phpcsFile->getTokens();
         $type      = strtolower($tokens[$stackPtr]['content']);
         $errorData = array($type);
-        
+
         $find   = PHP_CodeSniffer_Tokens::$methodPrefixes;
         $find[] = T_ABSTRACT;
         $find[] = T_WHITESPACE;

--- a/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/Sniffs/Commenting/FunctionCommentSniff.php
@@ -1,335 +1,402 @@
 <?php
 /**
- * Parses and verifies the doc comments for functions.
+ * Joomla! Coding Standard
  *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @copyright  Copyright (C) Open Source Matters, Inc. All rights reserved.
+ * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
-/**
- * Parses and verifies the doc comments for functions.
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
- * @version   Release: @package_version@
- * @link      http://pear.php.net/package/PHP_CodeSniffer
- */
-class Joomla_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer_Sniff
+
+if (class_exists('PEAR_Sniffs_Commenting_FunctionCommentSniff', true) === false)
 {
-    /**
-     * Returns an array of tokens this test wants to listen for.
-     *
-     * @return array
-     */
-    public function register()
-    {
-        return array(
-                 T_COMMENT,
-                 T_DOC_COMMENT_OPEN_TAG,
-                 T_CLASS,
-                 T_FUNCTION,
-                 T_OPEN_TAG,
-                );
+    throw new PHP_CodeSniffer_Exception('Class PEAR_Sniffs_Commenting_FunctionCommentSniff not found');
+}
 
-    }//end register()
+/**
+ * Extended ruleset for parsing and verifying the doc comments for functions.
+ */
+class Joomla_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commenting_FunctionCommentSniff
+{
+	/**
+	 * Process the return comment of this function comment.
+	 *
+	 * Extends PEAR.Commenting.FunctionComment.processReturn to exclude @return tag requirements for constructors and destructors and
+	 * to enforce alignment of the doc blocks.
+	 *
+	 * @param   PHP_CodeSniffer_File  $phpcsFile     The file being scanned.
+	 * @param   integer               $stackPtr      The position of the current token in the stack passed in $tokens.
+	 * @param   integer               $commentStart  The position in the stack where the comment started.
+	 *
+	 * @return  void
+	 *
+	 * @todo    Reinstate the check on the alignment of the tag
+	 */
+	protected function processReturn(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $commentStart)
+	{
+		$tokens = $phpcsFile->getTokens();
 
-    /**
-     * Processes this test, when one of its tokens is encountered.
-     *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
-     *
-     * @return void
-     */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
-    {
-        $tokens = $phpcsFile->getTokens();
-        $find   = PHP_CodeSniffer_Tokens::$methodPrefixes;
-        $find[] = T_WHITESPACE;
-        $commentEnd = $phpcsFile->findPrevious($find, ($stackPtr - 1), null, true);
-        if ($tokens[$commentEnd]['code'] === T_COMMENT) {
-            // Inline comments might just be closing comments for
-            // control structures or functions instead of function comments
-            // using the wrong comment type. If there is other code on the line,
-            // assume they relate to that code.
-            $prev = $phpcsFile->findPrevious($find, ($commentEnd - 1), null, true);
-            if ($prev !== false && $tokens[$prev]['line'] === $tokens[$commentEnd]['line']) {
-                $commentEnd = $prev;
-            }
-        }
-        if ($tokens[$commentEnd]['code'] !== T_DOC_COMMENT_CLOSE_TAG
-            && $tokens[$commentEnd]['code'] !== T_COMMENT
-        ) {
-            $phpcsFile->addError('Missing function doc comment', $stackPtr, 'Missing');
-            $phpcsFile->recordMetric($stackPtr, 'Function has doc comment', 'no');
-            return;
-        } else {
-            $phpcsFile->recordMetric($stackPtr, 'Function has doc comment', 'yes');
-        }
-        if ($tokens[$commentEnd]['code'] === T_COMMENT) {
-            $phpcsFile->addError('You must use "/**" style comments for a function comment', $stackPtr, 'WrongStyle');
-            return;
-        }
-        if ($tokens[$commentEnd]['line'] !== ($tokens[$stackPtr]['line'] - 1)) {
-            $error = 'There must be no blank lines after the function comment';
-            $phpcsFile->addError($error, $commentEnd, 'SpacingAfter');
-        }
-        $commentStart = $tokens[$commentEnd]['comment_opener'];
-        foreach ($tokens[$commentStart]['comment_tags'] as $tag) {
-            if ($tokens[$tag]['content'] === '@see') {
-                // Make sure the tag isn't empty.
-                $string = $phpcsFile->findNext(T_DOC_COMMENT_STRING, $tag, $commentEnd);
-                if ($string === false || $tokens[$string]['line'] !== $tokens[$tag]['line']) {
-                    $error = 'Content missing for @see tag in function comment';
-                    $phpcsFile->addError($error, $tag, 'EmptySees');
-                }
-            }
-        }
-        $this->processReturn($phpcsFile, $stackPtr, $commentStart);
-        $this->processThrows($phpcsFile, $stackPtr, $commentStart);
-        $this->processParams($phpcsFile, $stackPtr, $commentStart);
-    }//end process()
-    /**
-     * Process the return comment of this function comment.
-     *
-     * @param PHP_CodeSniffer_File $phpcsFile    The file being scanned.
-     * @param int                  $stackPtr     The position of the current token
-     *                                           in the stack passed in $tokens.
-     * @param int                  $commentStart The position in the stack where the comment started.
-     *
-     * @return void
-     */
-    protected function processReturn(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $commentStart)
-    {
-        $tokens = $phpcsFile->getTokens();
-        // Skip constructor and destructor.
-        $methodName      = $phpcsFile->getDeclarationName($stackPtr);
-        $isSpecialMethod = ($methodName === '__construct' || $methodName === '__destruct');
-        $return = null;
-        foreach ($tokens[$commentStart]['comment_tags'] as $tag) {
-            if ($tokens[$tag]['content'] === '@return') {
-                if ($return !== null) {
-                    $error = 'Only 1 @return tag is allowed in a function comment';
-                    $phpcsFile->addError($error, $tag, 'DuplicateReturn');
-                    return;
-                }
-                $return = $tag;
-            }
-        }
-        if ($isSpecialMethod === true) {
-            return;
-        }
-        if ($return !== null) {
-            $content = $tokens[($return + 2)]['content'];
-            if (empty($content) === true || $tokens[($return + 2)]['code'] !== T_DOC_COMMENT_STRING) {
-                $error = 'Return type missing for @return tag in function comment';
-                $phpcsFile->addError($error, $return, 'MissingReturnType');
-            }
-        } else {
-            $error = 'Missing @return tag in function comment';
-            $phpcsFile->addError($error, $tokens[$commentStart]['comment_closer'], 'MissingReturn');
-        }//end if
-    }//end processReturn()
-    /**
-     * Process any throw tags that this function comment has.
-     *
-     * @param PHP_CodeSniffer_File $phpcsFile    The file being scanned.
-     * @param int                  $stackPtr     The position of the current token
-     *                                           in the stack passed in $tokens.
-     * @param int                  $commentStart The position in the stack where the comment started.
-     *
-     * @return void
-     */
-    protected function processThrows(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $commentStart)
-    {
-        $tokens = $phpcsFile->getTokens();
-        $throws = array();
-        foreach ($tokens[$commentStart]['comment_tags'] as $tag) {
-            if ($tokens[$tag]['content'] !== '@throws') {
-                continue;
-            }
-            $exception = null;
-            $comment   = null;
-            if ($tokens[($tag + 2)]['code'] === T_DOC_COMMENT_STRING) {
-                $matches = array();
-                preg_match('/([^\s]+)(?:\s+(.*))?/', $tokens[($tag + 2)]['content'], $matches);
-                $exception = $matches[1];
-                if (isset($matches[2]) === true) {
-                    $comment = $matches[2];
-                }
-            }
-            if ($exception === null) {
-                $error = 'Exception type missing for @throws tag in function comment';
-                $phpcsFile->addError($error, $tag, 'InvalidThrows');
-            }
-        }//end foreach
-    }//end processThrows()
-    /**
-     * Process the function parameter comments.
-     *
-     * @param PHP_CodeSniffer_File $phpcsFile    The file being scanned.
-     * @param int                  $stackPtr     The position of the current token
-     *                                           in the stack passed in $tokens.
-     * @param int                  $commentStart The position in the stack where the comment started.
-     *
-     * @return void
-     */
-    protected function processParams(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $commentStart)
-    {
-        $tokens = $phpcsFile->getTokens();
-        $params  = array();
-        $maxType = 0;
-        $maxVar  = 0;
-        foreach ($tokens[$commentStart]['comment_tags'] as $pos => $tag) {
-            if ($tokens[$tag]['content'] !== '@param') {
-                continue;
-            }
-            $type      = '';
-            $typeSpace = 0;
-            $var       = '';
-            $varSpace  = 0;
-            $comment   = '';
-            if ($tokens[($tag + 2)]['code'] === T_DOC_COMMENT_STRING) {
-                $matches = array();
-                preg_match('/([^$&]+)(?:((?:\$|&)[^\s]+)(?:(\s+)(.*))?)?/', $tokens[($tag + 2)]['content'], $matches);
-                $typeLen   = strlen($matches[1]);
-                $type      = trim($matches[1]);
-                $typeSpace = ($typeLen - strlen($type));
-                $typeLen   = strlen($type);
-                if ($typeLen > $maxType) {
-                    $maxType = $typeLen;
-                }
-                if (isset($matches[2]) === true) {
-                    $var    = $matches[2];
-                    $varLen = strlen($var);
-                    if ($varLen > $maxVar) {
-                        $maxVar = $varLen;
-                    }
-                    if (isset($matches[4]) === true) {
-                        $varSpace = strlen($matches[3]);
-                        $comment  = $matches[4];
-                        // Any strings until the next tag belong to this comment.
-                        if (isset($tokens[$commentStart]['comment_tags'][($pos + 1)]) === true) {
-                            $end = $tokens[$commentStart]['comment_tags'][($pos + 1)];
-                        } else {
-                            $end = $tokens[$commentStart]['comment_closer'];
-                        }
-                        for ($i = ($tag + 3); $i < $end; $i++) {
-                            if ($tokens[$i]['code'] === T_DOC_COMMENT_STRING) {
-                                $comment .= ' '.$tokens[$i]['content'];
-                            }
-                        }
-                    } else {
-                        $error = 'Missing parameter comment';
-                        $phpcsFile->addError($error, $tag, 'MissingParamComment');
-                    }
-                } else {
-                    $error = 'Missing parameter name';
-                    $phpcsFile->addError($error, $tag, 'MissingParamName');
-                }//end if
-            } else {
-                $error = 'Missing parameter type';
-                $phpcsFile->addError($error, $tag, 'MissingParamType');
-            }//end if
-            $params[] = array(
-                         'tag'        => $tag,
-                         'type'       => $type,
-                         'var'        => $var,
-                         'comment'    => $comment,
-                         'type_space' => $typeSpace,
-                         'var_space'  => $varSpace,
-                        );
-        }//end foreach
-        $realParams  = $phpcsFile->getMethodParameters($stackPtr);
-        $foundParams = array();
-        foreach ($params as $pos => $param) {
-            if ($param['var'] === '') {
-                continue;
-            }
-            $foundParams[] = $param['var'];
-            // Check number of spaces after the type.
-            $spaces = ($maxType - strlen($param['type']) + 1);
-            if ($param['type_space'] !== $spaces) {
-                $error = 'Expected %s spaces after parameter type; %s found';
-                $data  = array(
-                          $spaces,
-                          $param['type_space'],
-                         );
-                $fix = $phpcsFile->addFixableError($error, $param['tag'], 'SpacingAfterParamType', $data);
-                if ($fix === true) {
-                    $content  = $param['type'];
-                    $content .= str_repeat(' ', $spaces);
-                    $content .= $param['var'];
-                    $content .= str_repeat(' ', $param['var_space']);
-                    $content .= $param['comment'];
-                    $phpcsFile->fixer->replaceToken(($param['tag'] + 2), $content);
-                }
-            }
-            // Make sure the param name is correct.
-            if (isset($realParams[$pos]) === true) {
-                $realName = $realParams[$pos]['name'];
-                if ($realName !== $param['var']) {
-                    $code = 'ParamNameNoMatch';
-                    $data = array(
-                             $param['var'],
-                             $realName,
-                            );
-                    $error = 'Doc comment for parameter %s does not match ';
-                    if (strtolower($param['var']) === strtolower($realName)) {
-                        $error .= 'case of ';
-                        $code   = 'ParamNameNoCaseMatch';
-                    }
-                    $error .= 'actual variable name %s';
-                    $phpcsFile->addError($error, $param['tag'], $code, $data);
-                }
-            } else if (substr($param['var'], -4) !== ',...') {
-                // We must have an extra parameter comment.
-                $error = 'Superfluous parameter comment';
-                $phpcsFile->addError($error, $param['tag'], 'ExtraParamComment');
-            }//end if
-            if ($param['comment'] === '') {
-                continue;
-            }
-            // Check number of spaces after the var name.
-            $spaces = ($maxVar - strlen($param['var']) + 1);
-            if ($param['var_space'] !== $spaces) {
-                $error = 'Expected %s spaces after parameter name; %s found';
-                $data  = array(
-                          $spaces,
-                          $param['var_space'],
-                         );
-                $fix = $phpcsFile->addFixableError($error, $param['tag'], 'SpacingAfterParamName', $data);
-                if ($fix === true) {
-                    $content  = $param['type'];
-                    $content .= str_repeat(' ', $param['type_space']);
-                    $content .= $param['var'];
-                    $content .= str_repeat(' ', $spaces);
-                    $content .= $param['comment'];
-                    $phpcsFile->fixer->replaceToken(($param['tag'] + 2), $content);
-                }
-            }
-        }//end foreach
-        $realNames = array();
-        foreach ($realParams as $realParam) {
-            $realNames[] = $realParam['name'];
-        }
-        // Report missing comments.
-        $diff = array_diff($realNames, $foundParams);
-        foreach ($diff as $neededParam) {
-            $error = 'Doc comment for parameter "%s" missing';
-            $data  = array($neededParam);
-            $phpcsFile->addError($error, $commentStart, 'MissingParamTag', $data);
-        }
-    }//end processParams()
-}//end class
+		$methodName      = $phpcsFile->getDeclarationName($stackPtr);
+		$isSpecialMethod = ($methodName === '__construct' || $methodName === '__destruct');
+
+		$return = null;
+
+		foreach ($tokens[$commentStart]['comment_tags'] as $tag)
+		{
+			if ($tokens[$tag]['content'] === '@return')
+			{
+				// Joomla Standard - Constructors and destructors should not have a @return tag
+				if ($isSpecialMethod)
+				{
+					$error = 'Constructor and destructor comments must not have a @return tag';
+					$phpcsFile->addError($error, $tag, 'UselessReturn');
+
+					return;
+				}
+				elseif ($return !== null)
+				{
+					$error = 'Only 1 @return tag is allowed in a function comment';
+					$phpcsFile->addError($error, $tag, 'DuplicateReturn');
+
+					return;
+				}
+
+				$return = $tag;
+			}
+		}
+
+		if ($isSpecialMethod === true)
+		{
+			return;
+		}
+
+		if ($return !== null)
+		{
+			$content = $tokens[($return + 2)]['content'];
+
+			if (empty($content) === true || $tokens[($return + 2)]['code'] !== T_DOC_COMMENT_STRING)
+			{
+				$error = 'Return type missing for @return tag in function comment';
+				$phpcsFile->addError($error, $return, 'MissingReturnType');
+			}
+			else
+			{
+				// Check return type (can have multiple return types separated by '|').
+				$typeNames      = explode('|', $content);
+				$suggestedNames = [];
+
+				foreach ($typeNames as $i => $typeName)
+				{
+					$suggestedName = PHP_CodeSniffer::suggestType($typeName);
+
+					if (in_array($suggestedName, $suggestedNames) === false)
+					{
+						$suggestedNames[] = $suggestedName;
+					}
+				}
+
+				$suggestedType = implode('|', $suggestedNames);
+
+				if ($content !== $suggestedType)
+				{
+					$error = 'Expected "%s" but found "%s" for function return type';
+					$data  = array(
+						$suggestedType,
+						$content
+					);
+
+					$fix = $phpcsFile->addFixableError($error, $return, 'InvalidReturn', $data);
+
+					if ($fix === true)
+					{
+						$phpcsFile->fixer->replaceToken(($return + 2), $suggestedType);
+					}
+				}
+
+				/*
+				 * If return type is not void, there needs to be a return statement somewhere in the function that returns something.
+				 * Skip this check for mixed return types.
+				 */
+				if (!in_array($content, ['void', 'mixed']))
+				{
+					if (isset($tokens[$stackPtr]['scope_closer']) === true)
+					{
+						$endToken    = $tokens[$stackPtr]['scope_closer'];
+						$returnToken = $phpcsFile->findNext([T_RETURN, T_YIELD], $stackPtr, $endToken);
+
+						if ($returnToken === false)
+						{
+							$error = 'Function return type is not void, but function has no return statement';
+							$phpcsFile->addError($error, $return, 'InvalidNoReturn');
+						}
+						else
+						{
+							$semicolon = $phpcsFile->findNext(T_WHITESPACE, ($returnToken + 1), null, true);
+
+							if ($tokens[$semicolon]['code'] === T_SEMICOLON)
+							{
+								$error = 'Function return type is not void, but function is returning void here';
+								$phpcsFile->addError($error, $returnToken, 'InvalidReturnNotVoid');
+							}
+						}
+					}
+				}
+			}
+		}
+		else
+		{
+			$error = 'Missing @return tag in function comment';
+			$phpcsFile->addError($error, $tokens[$commentStart]['comment_closer'], 'MissingReturn');
+		}
+	}
+
+	/**
+	 * Process the function parameter comments.
+	 *
+	 * Extends PEAR.Commenting.FunctionComment.processReturn to enforce correct alignment of the doc block.
+	 *
+	 * @param   PHP_CodeSniffer_File $phpcsFile     The file being scanned.
+	 * @param   integer              $stackPtr      The position of the current token in the stack passed in $tokens.
+	 * @param   integer              $commentStart  The position in the stack where the comment started.
+	 *
+	 * @return  void
+	 *
+	 * @todo    Reinstate the check that params come after the function's comment and has a blank line before them
+	 * @todo    Reinstate the check that there is a blank line after all params are declared
+	 */
+	protected function processParams(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $commentStart)
+	{
+		$tokens = $phpcsFile->getTokens();
+
+		$params  = array();
+		$maxType = 0;
+		$maxVar  = 0;
+
+		foreach ($tokens[$commentStart]['comment_tags'] as $pos => $tag)
+		{
+			if ($tokens[$tag]['content'] !== '@param')
+			{
+				continue;
+			}
+
+			$type      = '';
+			$typeSpace = 0;
+			$var       = '';
+			$varSpace  = 0;
+			$comment   = '';
+
+			if ($tokens[($tag + 2)]['code'] === T_DOC_COMMENT_STRING)
+			{
+				$matches = [];
+				preg_match('/([^$&]+)(?:((?:\$|&)[^\s]+)(?:(\s+)(.*))?)?/', $tokens[($tag + 2)]['content'], $matches);
+
+				$typeLen   = strlen($matches[1]);
+				$type      = trim($matches[1]);
+				$typeSpace = ($typeLen - strlen($type));
+				$typeLen   = strlen($type);
+
+				if ($typeLen > $maxType)
+				{
+					$maxType = $typeLen;
+				}
+
+				if (isset($matches[2]) === true)
+				{
+					$var    = $matches[2];
+					$varLen = strlen($var);
+
+					if ($varLen > $maxVar)
+					{
+						$maxVar = $varLen;
+					}
+
+					if (isset($matches[4]) === true)
+					{
+						$varSpace = strlen($matches[3]);
+						$comment  = $matches[4];
+
+						// Any strings until the next tag belong to this comment.
+						if (isset($tokens[$commentStart]['comment_tags'][($pos + 1)]) === true)
+						{
+							$end = $tokens[$commentStart]['comment_tags'][($pos + 1)];
+						}
+						else
+						{
+							$end = $tokens[$commentStart]['comment_closer'];
+						}
+
+						for ($i = ($tag + 3); $i < $end; $i++)
+						{
+							if ($tokens[$i]['code'] === T_DOC_COMMENT_STRING)
+							{
+								$comment .= ' ' . $tokens[$i]['content'];
+							}
+						}
+					}
+					else
+					{
+						$error = 'Missing parameter comment';
+						$phpcsFile->addError($error, $tag, 'MissingParamComment');
+					}
+				}
+				else
+				{
+					$error = 'Missing parameter name';
+					$phpcsFile->addError($error, $tag, 'MissingParamName');
+				}
+			}
+			else
+			{
+				$error = 'Missing parameter type';
+				$phpcsFile->addError($error, $tag, 'MissingParamType');
+			}
+
+			$params[] = array(
+				'tag'         => $tag,
+				'type'        => $type,
+				'var'         => $var,
+				'comment'     => $comment,
+				'type_space'  => $typeSpace,
+				'var_space'   => $varSpace,
+				'align_space' => $tokens[($tag + 1)]['content']
+			);
+		}
+
+		$realParams    = $phpcsFile->getMethodParameters($stackPtr);
+		$foundParams   = [];
+		$previousParam = null;
+
+		foreach ($params as $pos => $param)
+		{
+			if ($param['var'] === '')
+			{
+				continue;
+			}
+
+			$foundParams[] = $param['var'];
+
+			// Joomla change: There must be 3 spaces after the @param tag to make it line up with the @return tag
+			if ($param['align_space'] !== '   ')
+			{
+				$error = 'Expected 3 spaces before variable type, found %s';
+				$data  = array(strlen($param['align_space']));
+				$phpcsFile->addError($error, $param['tag'], 'BeforeParamType', $data);
+			}
+
+			// Make sure the param name is correct.
+			if (isset($realParams[$pos]) === true)
+			{
+				$realName = $realParams[$pos]['name'];
+				if ($realName !== $param['var'])
+				{
+					$code = 'ParamNameNoMatch';
+					$data = array(
+						$param['var'],
+						$realName
+					);
+
+					$error = 'Doc comment for parameter %s does not match ';
+
+					if (strtolower($param['var']) === strtolower($realName))
+					{
+						$error .= 'case of ';
+						$code = 'ParamNameNoCaseMatch';
+					}
+
+					$error .= 'actual variable name %s';
+
+					$phpcsFile->addError($error, $param['tag'], $code, $data);
+				}
+			}
+			else if (substr($param['var'], -4) !== ',...')
+			{
+				// We must have an extra parameter comment.
+				$error = 'Superfluous parameter comment';
+				$phpcsFile->addError($error, $param['tag'], 'ExtraParamComment');
+			}
+
+			if ($param['comment'] === '')
+			{
+				continue;
+			}
+
+			// Joomla change: Enforces alignment of the param variables and comments
+			if ($previousParam !== null)
+			{
+				$previousName = ($previousParam['var'] !== '') ? $previousParam['var'] : 'UNKNOWN';
+
+				// Check to see if the parameters align properly.
+				if (!$this->paramVarsAlign($param, $previousParam))
+				{
+					$error = 'The variable names for parameters %s and %s do not align';
+					$data  = array(
+						$previousName,
+						$param['var']
+					);
+					$phpcsFile->addError($error, $param['tag'], 'ParameterNamesNotAligned', $data);
+				}
+
+				// Check to see if the comments align properly.
+				if (!$this->paramCommentsAlign($param, $previousParam))
+				{
+					$error = 'The comments for parameters %s and %s do not align';
+					$data  = array(
+						$previousName,
+						$param['var']
+					);
+					$phpcsFile->addError($error, $param['tag'], 'ParameterCommentsNotAligned', $data);
+				}
+			}
+
+			$previousParam = $param;
+		}
+
+		$realNames = array();
+
+		foreach ($realParams as $realParam)
+		{
+			$realNames[] = $realParam['name'];
+		}
+
+		// Report missing comments.
+		$diff = array_diff($realNames, $foundParams);
+
+		foreach ($diff as $neededParam)
+		{
+			$error = 'Doc comment for parameter "%s" missing';
+			$data  = array($neededParam);
+			$phpcsFile->addError($error, $commentStart, 'MissingParamTag', $data);
+		}
+
+	}
+
+	/**
+	 * Ensure the method's parameter comments align
+	 *
+	 * @param   array  $param          The current parameter being checked
+	 * @param   array  $previousParam  The previous parameter that was checked
+	 *
+	 * @return  boolean
+	 */
+	private function paramCommentsAlign($param, $previousParam)
+	{
+		$paramStringLength         = strlen($param['type']) + $param['type_space'] + strlen($param['var']) + $param['var_space'];
+		$previousParamStringLength = strlen($previousParam['type']) + $previousParam['type_space'] + strlen($previousParam['var']) + $previousParam['var_space'];
+
+		return $paramStringLength === $previousParamStringLength;
+	}
+
+	/**
+	 * Ensure the method's parameter variable names align
+	 *
+	 * @param   array  $param          The current parameter being checked
+	 * @param   array  $previousParam  The previous parameter that was checked
+	 *
+	 * @return  boolean
+	 */
+	private function paramVarsAlign($param, $previousParam)
+	{
+		$paramStringLength         = strlen($param['type']) + $param['type_space'];
+		$previousParamStringLength = strlen($previousParam['type']) + $previousParam['type_space'];
+
+		return $paramStringLength === $previousParamStringLength;
+	}
+}

--- a/Sniffs/ControlStructures/ControlSignatureSniff.php
+++ b/Sniffs/ControlStructures/ControlSignatureSniff.php
@@ -1,62 +1,49 @@
 <?php
 /**
- * Verifies that control statements conform to their coding standards.
+ * Joomla! Coding Standard
  *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @copyright  Copyright (C) Open Source Matters, Inc. All rights reserved.
+ * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
-if (class_exists('PHP_CodeSniffer_Standards_AbstractPatternSniff', true) === false) {
-    throw new PHP_CodeSniffer_Exception('Class PHP_CodeSniffer_Standards_AbstractPatternSniff not found');
+
+if (class_exists('PHP_CodeSniffer_Standards_AbstractPatternSniff', true) === false)
+{
+	throw new PHP_CodeSniffer_Exception('Class PHP_CodeSniffer_Standards_AbstractPatternSniff not found');
 }
+
 /**
  * Verifies that control statements conform to their coding standards.
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
- * @version   Release: @package_version@
- * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
 class Joomla_Sniffs_ControlStructures_ControlSignatureSniff extends PHP_CodeSniffer_Standards_AbstractPatternSniff
 {
-    /**
-     * If true, comments will be ignored if they are found in the code.
-     *
-     * @var boolean
-     */
-    public $ignoreComments = true;
+	/**
+	 * If true, comments will be ignored if they are found in the code.
+	 *
+	 * @var  boolean
+	 */
+	public $ignoreComments = true;
 
-    /**
-     * A list of tokenizers this sniff supports.
-     *
-     * @var array
-     */
-    public $supportedTokenizers = array(
-                                   'PHP',
-                                   'JS',
-                                  );
+	/**
+	 * A list of tokenizers this sniff supports.
+	 *
+	 * @var  array
+	 */
+	public $supportedTokenizers = array(
+		'PHP',
+		'JS',
+	);
 
-    /**
-     * Returns the patterns that this test wishes to verify.
-     *
-     * @return string[]
-     */
-    protected function getPatterns()
-    {
+	/**
+	 * Returns the patterns that this test wishes to verify.
+	 *
+	 * @return  string[]
+	 */
+	protected function getPatterns()
+	{
 		return array(
-			'if (...)EOL',
-			'}EOL...elseif (...)EOL',
-			'}EOL...elseEOL',
+			'if (...)EOL...{EOL',
+			'}EOL...elseif (...)EOL...{EOL',
+			'}EOL...elseEOL...{EOL',
 			'tryEOL...{EOL...}EOL',
 			'catch (...)EOL...{EOL',
 			'doEOL...{...}EOL',
@@ -65,6 +52,5 @@ class Joomla_Sniffs_ControlStructures_ControlSignatureSniff extends PHP_CodeSnif
 			'foreach (...)EOL...{EOL',
 			'switch (...)EOL...{EOL',
 		);
-	}//end getPatterns()
-}//end class
-?>
+	}
+}

--- a/Sniffs/ControlStructures/WhiteSpaceBeforeSniff.php
+++ b/Sniffs/ControlStructures/WhiteSpaceBeforeSniff.php
@@ -1,15 +1,9 @@
 <?php
 /**
- * Joomla_Sniffs_ControlStructures_WhiteSpaceBeforeSniff.
+ * Joomla! Coding Standard
  *
- * PHP version 5
- *
- * @package     PHP_CodeSniffer
- * @subpackage  PHP
- * @author      Nikolai Plath <der.el.kuku@gmail.com>
- * @copyright   2012 OSM
- * @license     http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @link        http://pear.php.net/package/PHP_CodeSniffer
+ * @copyright  Copyright (C) Open Source Matters, Inc. All rights reserved.
+ * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 
 /**
@@ -36,36 +30,25 @@
  *
  * This rule applies for the structures:
  * <b>if, for, foreach, while, switch, try and return</b>
- *
- * @version    Release: 1.3.0RC1
- * @category   PHP
- * @package    PHP_CodeSniffer
- * @author     Greg Sherwood <gsherwood@squiz.net>
- * @author     Marc McIntyre <mmcintyre@squiz.net>
- * @copyright  2006 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license    http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
- * @link       http://pear.php.net/package/PHP_CodeSniffer
- *
- * @since      1.0
  */
 class Joomla_Sniffs_ControlStructures_WhiteSpaceBeforeSniff implements PHP_CodeSniffer_Sniff
 {
 	/**
 	 * Registers the tokens that this sniff wants to listen for.
 	 *
-	 * @return array
+	 * @return  array
 	 */
 	public function register()
 	{
 		return array(
-			T_IF
-		, T_FOR
-		, T_FOREACH
-		, T_SWITCH
-		, T_TRY
-		, T_WHILE
-		, T_DO
-		, T_RETURN
+			T_IF,
+			T_FOR,
+			T_FOREACH,
+			T_SWITCH,
+			T_TRY,
+			T_WHILE,
+			T_DO,
+			T_RETURN
 		);
 	}
 
@@ -75,14 +58,13 @@ class Joomla_Sniffs_ControlStructures_WhiteSpaceBeforeSniff implements PHP_CodeS
 	 * @param   PHP_CodeSniffer_File  $phpcsFile  The file being scanned.
 	 * @param   integer               $stackPtr   The position of the current token in the stack passed in $tokens.
 	 *
-	 * @return void
+	 * @return  void
 	 */
 	public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
 	{
 		$tokens = $phpcsFile->getTokens();
 
-		if (isset($tokens[$stackPtr]['scope_opener']) === false
-			&& $tokens[$stackPtr]['code'] != T_RETURN)
+		if (isset($tokens[$stackPtr]['scope_opener']) === false && $tokens[$stackPtr]['code'] != T_RETURN)
 		{
 			return;
 		}
@@ -91,11 +73,12 @@ class Joomla_Sniffs_ControlStructures_WhiteSpaceBeforeSniff implements PHP_CodeS
 
 		if ($tokens[$stackPtr]['line'] - 1 == $tokens[$previousSemicolon]['line'])
 		{
-			$error = sprintf('Please consider an empty line before the %s statement;',
+			$error = 'Please consider an empty line before the %s statement;';
+			$data = array(
 				$tokens[$stackPtr]['content']
 			);
 
-			$phpcsFile->addError($error, $stackPtr, 'SpaceBefore');
+			$phpcsFile->addError($error, $stackPtr, 'SpaceBefore', $data);
 
 			return;
 		}

--- a/Sniffs/Functions/StatementNotFunctionSniff.php
+++ b/Sniffs/Functions/StatementNotFunctionSniff.php
@@ -1,17 +1,15 @@
 <?php
 /**
- * Joomla_Sniffs_Functions_StatementNotFunctionSniff.
+ * Joomla! Coding Standard
  *
- * @copyright  Copyright (C) 2005 - 2014 Open Source Matters, Inc. All rights reserved.
- * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @copyright  Copyright (C) Open Source Matters, Inc. All rights reserved.
+ * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 
 /**
  * Joomla_Sniffs_Functions_StatementNotFunctionSniff.
  *
  * Checks that language statements do no use brackets.
- *
- * @since  1.1
  */
 class Joomla_Sniffs_Functions_StatementNotFunctionSniff implements PHP_CodeSniffer_Sniff
 {
@@ -36,10 +34,9 @@ class Joomla_Sniffs_Functions_StatementNotFunctionSniff implements PHP_CodeSniff
 	 * Processes this test, when one of its tokens is encountered.
 	 *
 	 * @param   PHP_CodeSniffer_File  $phpcsFile  The file being scanned.
-	 * @param   int                   $stackPtr   The position of the current token in the
-	 *                                            stack passed in $tokens.
+	 * @param   integer               $stackPtr   The position of the current token in the stack passed in $tokens.
 	 *
-	 * @return void
+	 * @return  void
 	 */
 	public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
 	{

--- a/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -1,293 +1,128 @@
 <?php
 /**
- * PEAR_Sniffs_NamingConventions_ValidFunctionNameSniff.
+ * Joomla! Coding Standard
  *
- * PHP version 5
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * @copyright  Copyright (C) Open Source Matters, Inc. All rights reserved.
+ * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
  */
 
-if (class_exists('PHP_CodeSniffer_Standards_AbstractScopeSniff', true) === false) {
-    throw new PHP_CodeSniffer_Exception('Class PHP_CodeSniffer_Standards_AbstractScopeSniff not found');
+if (class_exists('PEAR_Sniffs_NamingConventions_ValidFunctionNameSniff', true) === false)
+{
+	throw new PHP_CodeSniffer_Exception('Class PEAR_Sniffs_NamingConventions_ValidFunctionNameSniff not found');
 }
 
 /**
- * PEAR_Sniffs_NamingConventions_ValidFunctionNameSniff.
- *
- * Ensures method names are correct depending on whether they are public
- * or private, and that functions are named correctly.
- *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    Greg Sherwood <gsherwood@squiz.net>
- * @author    Marc McIntyre <mmcintyre@squiz.net>
- * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
- * @version   Release: @package_version@
- * @link      http://pear.php.net/package/PHP_CodeSniffer
+ * Extended ruleset for ensuring method and function names are correct.
  */
-class Joomla_Sniffs_NamingConventions_ValidFunctionNameSniff extends PHP_CodeSniffer_Standards_AbstractScopeSniff
+class Joomla_Sniffs_NamingConventions_ValidFunctionNameSniff extends PEAR_Sniffs_NamingConventions_ValidFunctionNameSniff
 {
-    /**
-     * A list of all PHP magic methods.
-     *
-     * @var array
-     */
-    protected $magicMethods = array(
-                               'construct',
-                               'destruct',
-                               'call',
-                               'callStatic',
-                               'get',
-                               'set',
-                               'isset',
-                               'unset',
-                               'sleep',
-                               'wakeup',
-                               'toString',
-                               'set_state',
-                               'clone',
-                               'invoke',
-                              );
+	/**
+	 * Processes the tokens within the scope.
+	 *
+	 * Extends PEAR.NamingConventions.ValidFunctionName.processTokenWithinScope to remove the requirement for leading underscores on
+	 * private method names.
+	 *
+	 * @param   PHP_CodeSniffer_File $phpcsFile  The file being processed.
+	 * @param   integer              $stackPtr   The position where this token was found.
+	 * @param   integer              $currScope  The position of the current scope.
+	 *
+	 * @return  void
+	 */
+	protected function processTokenWithinScope(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $currScope)
+	{
+		$methodName = $phpcsFile->getDeclarationName($stackPtr);
 
-    /**
-     * A list of all PHP magic functions.
-     *
-     * @var array
-     */
-    protected $magicFunctions = array('autoload' => true);
+		if ($methodName === null)
+		{
+			// Ignore closures.
+			return;
+		}
 
-    /**
-     * Constructs a Joomla_Sniffs_NamingConventions_ValidFunctionNameSniff.
-     */
-    public function __construct()
-    {
-        parent::__construct(array(T_CLASS, T_INTERFACE, T_TRAIT), array(T_FUNCTION), true);
+		$className = $phpcsFile->getDeclarationName($currScope);
+		$errorData = array($className . '::' . $methodName);
 
-    }//end __construct()
+		// Is this a magic method. i.e., is prefixed with "__" ?
+		if (preg_match('|^__|', $methodName) !== 0)
+		{
+			$magicPart = strtolower(substr($methodName, 2));
 
- /**
-     * Processes the tokens within the scope.
-     *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being processed.
-     * @param int                  $stackPtr  The position where this token was
-     *                                        found.
-     * @param int                  $currScope The position of the current scope.
-     *
-     * @return void
-     */
-    protected function processTokenWithinScope(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $currScope)
-    {
-        $methodName = $phpcsFile->getDeclarationName($stackPtr);
-        if ($methodName === null) {
-            // Ignore closures.
-            return;
-        }
+			if (isset($this->magicMethods[$magicPart]) === false)
+			{
+				$error = 'Method name "%s" is invalid; only PHP magic methods should be prefixed with a double underscore';
+				$phpcsFile->addError($error, $stackPtr, 'MethodDoubleUnderscore', $errorData);
+			}
 
-        $className = $phpcsFile->getDeclarationName($currScope);
-        $errorData = array($className.'::'.$methodName);
+			return;
+		}
 
-        // Is this a magic method. i.e., is prefixed with "__" ?
-        if (preg_match('|^__|', $methodName) !== 0) {
-            $magicPart = strtolower(substr($methodName, 2));
-            if (isset($this->magicMethods[$magicPart]) === false) {
-                 $error = 'Method name "%s" is invalid; only PHP magic methods should be prefixed with a double underscore';
-                 $phpcsFile->addError($error, $stackPtr, 'MethodDoubleUnderscore', $errorData);
-            }
+		// PHP4 constructors are allowed to break our rules.
+		if ($methodName === $className)
+		{
+			return;
+		}
 
-            return;
-        }
+		// PHP4 destructors are allowed to break our rules.
+		if ($methodName === '_' . $className)
+		{
+			return;
+		}
 
-        // PHP4 constructors are allowed to break our rules.
-        if ($methodName === $className) {
-            return;
-        }
+		$methodProps    = $phpcsFile->getMethodProperties($stackPtr);
+		$scope          = $methodProps['scope'];
+		$scopeSpecified = $methodProps['scope_specified'];
 
-        // PHP4 destructors are allowed to break our rules.
-        if ($methodName === '_'.$className) {
-            return;
-        }
+		if ($methodProps['scope'] === 'private')
+		{
+			$isPublic = false;
+		}
+		else
+		{
+			$isPublic = true;
+		}
 
-        $methodProps    = $phpcsFile->getMethodProperties($stackPtr);
-        $scope          = $methodProps['scope'];
-        $scopeSpecified = $methodProps['scope_specified'];
+		// Joomla change: Methods must not have an underscore on the front.
+		if ($scopeSpecified === true && $methodName{0} === '_')
+		{
+			$error = '%s method name "%s" must not be prefixed with an underscore';
+			$data  = array(
+				ucfirst($scope),
+				$errorData[0],
+			);
 
-        if ($methodProps['scope'] === 'private') {
-            $isPublic = false;
-        } else {
-            $isPublic = true;
-        }
+			$phpcsFile->addError($error, $stackPtr, 'MethodUnderscore', $data);
+			$phpcsFile->recordMetric($stackPtr, 'Method prefixed with underscore', 'yes');
 
-        // If it's a private method, it must have an underscore on the front.
-        if ($isPublic === false) {
-            if ($methodName{0} !== '_') {
-                $error = 'Private method name "%s" must be prefixed with an underscore';
-                $phpcsFile->addError($error, $stackPtr, 'PrivateNoUnderscore', $errorData);
-                $phpcsFile->recordMetric($stackPtr, 'Private method prefixed with underscore', 'no');
-                return;
-            } else {
-                $phpcsFile->recordMetric($stackPtr, 'Private method prefixed with underscore', 'yes');
-            }
-        }
+			return;
+		}
 
-        // If it's not a private method, it must not have an underscore on the front.
-        if ($isPublic === true && $scopeSpecified === true && $methodName{0} === '_') {
-            $error = '%s method name "%s" must not be prefixed with an underscore';
-            $data  = array(
-                      ucfirst($scope),
-                      $errorData[0],
-                     );
-            $phpcsFile->addError($error, $stackPtr, 'PublicUnderscore', $data);
-            return;
-        }
+		// If the scope was specified on the method, then the method must be camel caps and an underscore should be checked for. If it wasn't
+		// specified, treat it like a public method and remove the underscore prefix if there is one because we cant determine if it is private or
+		// public.
+		$testMethodName = $methodName;
 
-        // If the scope was specified on the method, then the method must be
-        // camel caps and an underscore should be checked for. If it wasn't
-        // specified, treat it like a public method and remove the underscore
-        // prefix if there is one because we cant determine if it is private or
-        // public.
-        $testMethodName = $methodName;
-        if ($scopeSpecified === false && $methodName{0} === '_') {
-            $testMethodName = substr($methodName, 1);
-        }
+		if ($scopeSpecified === false && $methodName{0} === '_')
+		{
+			$testMethodName = substr($methodName, 1);
+		}
 
-        if (PHP_CodeSniffer::isCamelCaps($testMethodName, false, $isPublic, false) === false) {
-            if ($scopeSpecified === true) {
-                $error = '%s method name "%s" is not in camel caps format';
-                $data  = array(
-                          ucfirst($scope),
-                          $errorData[0],
-                         );
-                $phpcsFile->addError($error, $stackPtr, 'ScopeNotCamelCaps', $data);
-            } else {
-                $error = 'Method name "%s" is not in camel caps format';
-                $phpcsFile->addError($error, $stackPtr, 'NotCamelCaps', $errorData);
-            }
+		if (PHP_CodeSniffer::isCamelCaps($testMethodName, false, true, false) === false)
+		{
+			if ($scopeSpecified === true)
+			{
+				$error = '%s method name "%s" is not in camel caps format';
+				$data  = array(
+					ucfirst($scope),
+					$errorData[0],
+				);
+				$phpcsFile->addError($error, $stackPtr, 'ScopeNotCamelCaps', $data);
+			}
+			else
+			{
+				$error = 'Method name "%s" is not in camel caps format';
+				$phpcsFile->addError($error, $stackPtr, 'NotCamelCaps', $errorData);
+			}
 
-            return;
-        }
-
-    }//end processTokenWithinScope()
-
-    /**
-     * Processes the tokens outside the scope.
-     *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being processed.
-     * @param int                  $stackPtr  The position where this token was
-     *                                        found.
-     *
-     * @return void
-     */
-    protected function processTokenOutsideScope(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
-    {
-        $functionName = $phpcsFile->getDeclarationName($stackPtr);
-        if ($functionName === null) {
-            // Ignore closures.
-            return;
-        }
-
-        if (ltrim($functionName, '_') === '') {
-            // Ignore special functions.
-            return;
-        }
-
-        $errorData = array($functionName);
-
-        // Is this a magic function. i.e., it is prefixed with "__".
-        if (preg_match('|^__|', $functionName) !== 0) {
-            $magicPart = strtolower(substr($functionName, 2));
-            if (isset($this->magicFunctions[$magicPart]) === false) {
-                 $error = 'Function name "%s" is invalid; only PHP magic methods should be prefixed with a double underscore';
-                 $phpcsFile->addError($error, $stackPtr, 'FunctionDoubleUnderscore', $errorData);
-            }
-
-            return;
-        }
-
-        // Function names can be in two parts; the package name and
-        // the function name.
-        $packagePart   = '';
-        $camelCapsPart = '';
-        $underscorePos = strrpos($functionName, '_');
-        if ($underscorePos === false) {
-            $camelCapsPart = $functionName;
-        } else {
-            $packagePart   = substr($functionName, 0, $underscorePos);
-            $camelCapsPart = substr($functionName, ($underscorePos + 1));
-
-            // We don't care about _'s on the front.
-            $packagePart = ltrim($packagePart, '_');
-        }
-
-        // If it has a package part, make sure the first letter is a capital.
-        if ($packagePart !== '') {
-            if ($functionName{0} === '_') {
-                $error = 'Function name "%s" is invalid; only private methods should be prefixed with an underscore';
-                $phpcsFile->addError($error, $stackPtr, 'FunctionUnderscore', $errorData);
-                return;
-            }
-
-            if ($functionName{0} !== strtoupper($functionName{0})) {
-                $error = 'Function name "%s" is prefixed with a package name but does not begin with a capital letter';
-                $phpcsFile->addError($error, $stackPtr, 'FunctionNoCapital', $errorData);
-                return;
-            }
-        }
-
-        // If it doesn't have a camel caps part, it's not valid.
-        if (trim($camelCapsPart) === '') {
-            $error = 'Function name "%s" is not valid; name appears incomplete';
-            $phpcsFile->addError($error, $stackPtr, 'FunctionInvalid', $errorData);
-            return;
-        }
-
-        $validName        = true;
-        $newPackagePart   = $packagePart;
-        $newCamelCapsPart = $camelCapsPart;
-
-        // Every function must have a camel caps part, so check that first.
-        if (PHP_CodeSniffer::isCamelCaps($camelCapsPart, false, true, false) === false) {
-            $validName        = false;
-            $newCamelCapsPart = strtolower($camelCapsPart{0}).substr($camelCapsPart, 1);
-        }
-
-        if ($packagePart !== '') {
-            // Check that each new word starts with a capital.
-            $nameBits = explode('_', $packagePart);
-            foreach ($nameBits as $bit) {
-                if ($bit{0} !== strtoupper($bit{0})) {
-                    $newPackagePart = '';
-                    foreach ($nameBits as $bit) {
-                        $newPackagePart .= strtoupper($bit{0}).substr($bit, 1).'_';
-                    }
-
-                    $validName = false;
-                    break;
-                }
-            }
-        }
-
-        if ($validName === false) {
-            $newName = rtrim($newPackagePart, '_').'_'.$newCamelCapsPart;
-            if ($newPackagePart === '') {
-                $newName = $newCamelCapsPart;
-            } else {
-                $newName = rtrim($newPackagePart, '_').'_'.$newCamelCapsPart;
-            }
-
-            $error  = 'Function name "%s" is invalid; consider "%s" instead';
-            $data   = $errorData;
-            $data[] = $newName;
-            $phpcsFile->addError($error, $stackPtr, 'FunctionNameInvalid', $data);
-        }
-
-    }//end processTokenOutsideScope()
-
-
-}//end class
+			return;
+		}
+	}
+}

--- a/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Joomla! Coding Standard
+ *
+ * @copyright  Copyright (C) Open Source Matters, Inc. All rights reserved.
+ * @license    http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License Version 2 or Later
+ */
+
+if (class_exists('Squiz_Sniffs_NamingConventions_ValidVariableNameSniff', true) === false)
+{
+	throw new PHP_CodeSniffer_Exception('Class Squiz_Sniffs_NamingConventions_ValidVariableNameSniff not found');
+}
+
+/**
+ * Extended ruleset for checking the naming of variables and member variables.
+ */
+class Joomla_Sniffs_NamingConventions_ValidVariableNameSniff extends Squiz_Sniffs_NamingConventions_ValidVariableNameSniff
+{
+	/**
+	 * Processes class member variables.
+	 *
+	 * Extends Squiz.NamingConventions.ValidVariableName.processMemberVar to remove the requirement for leading underscores on
+	 * private member vars.
+	 *
+	 * @param   PHP_CodeSniffer_File  $phpcsFile  The file being scanned.
+	 * @param   integer               $stackPtr   The position of the current token in the stack passed in $tokens.
+	 *
+	 * @return  void
+	 */
+	protected function processMemberVar(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+	{
+		$tokens = $phpcsFile->getTokens();
+
+		$varName     = ltrim($tokens[$stackPtr]['content'], '$');
+		$memberProps = $phpcsFile->getMemberProperties($stackPtr);
+
+		if (empty($memberProps) === true)
+		{
+			// Couldn't get any info about this variable, which generally means it is invalid or possibly has a parse
+			// error. Any errors will be reported by the core, so we can ignore it.
+			return;
+		}
+
+		$errorData = array($varName);
+
+		if (substr($varName, 0, 1) === '_')
+		{
+			$error = '%s member variable "%s" must not contain a leading underscore';
+			$data  = array(
+				ucfirst($memberProps['scope']),
+				$errorData[0]
+			);
+			$phpcsFile->addError($error, $stackPtr, 'ClassVarHasUnderscore', $data);
+
+			return;
+		}
+
+		if (PHP_CodeSniffer::isCamelCaps($varName, false, true, false) === false)
+		{
+			$error = 'Member variable "%s" is not in valid camel caps format';
+			$phpcsFile->addError($error, $stackPtr, 'MemberNotCamelCaps', $errorData);
+		}
+	}
+}

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -75,7 +75,6 @@
 	<rule ref="Squiz.CSS.SemicolonSpacing" />
 	<rule ref="Squiz.Classes.SelfMemberReference" />
 	<rule ref="Squiz.Commenting.DocCommentAlignment" />
-	<rule ref="Squiz.NamingConventions.ValidVariableName" />
 	<rule ref="Squiz.Operators.IncrementDecrementUsage">
 		<exclude name="Squiz.Operators.IncrementDecrementUsage.processAssignment" />
 	</rule>


### PR DESCRIPTION
- Re-implements some of the extended checks, keeps fully customized sniffs to a minimum by extending parents as needed
  - Doc block alignment for `@param` checks
  - Constructor/destructor should not have `@return` tags
  - Private underscores are discouraged (disallowed here, the CMS will need to customize this rule)
  - Flagged missing checks from current standards as `@todo` in method doc blocks
- Comments custom sniffs with what is extended and why
- Autoformats most of our sniff classes to our PHPCS standard
