### PR TITLE
empty arrays are valid too

### DIFF
--- a/Joomla/Sniffs/Classes/InstantiateNewClassesSniff.php
+++ b/Joomla/Sniffs/Classes/InstantiateNewClassesSniff.php
@@ -66,6 +66,9 @@ class Joomla_Sniffs_Classes_InstantiateNewClassesSniff implements PHP_CodeSniffe
 					case T_LNUMBER :
 					case T_CONSTANT_ENCAPSED_STRING :
 					case T_DOUBLE_QUOTED_STRING :
+					case T_ARRAY :
+					case T_TRUE :
+					case T_FALSE :
 						if ($started === true)
 						{
 							$valid   = true;


### PR DESCRIPTION
Adding 1 year old fix https://github.com/joomla/coding-standards/pull/86 ... thx @SniperSister
Also adding T_TRUE and T_FALSE since `new Class(true)` and `new Class(false)` are also valid...
