### PR TITLE
Always exclude T_SELF

### DIFF
--- a/Joomla/Sniffs/Classes/InstantiateNewClassesSniff.php
+++ b/Joomla/Sniffs/Classes/InstantiateNewClassesSniff.php
@@ -129,6 +129,7 @@ class Joomla_Sniffs_Classes_InstantiateNewClassesSniff implements PHP_CodeSniffe
 						T_WHITESPACE,
 						T_NS_SEPARATOR,
 						T_STRING,
+						T_SELF,
 					),
 					($stackPtr + 1),
 					null,


### PR DESCRIPTION
Fixes the issue with 

```
$k = new self();
$k = new self( );
$k = new self ();
```

Removing the self keyword (I think) - at least your tests pass now......